### PR TITLE
FEAT: add login/register screen

### DIFF
--- a/app/src/main/java/com/example/emptyactivity/LoginRegister.kt
+++ b/app/src/main/java/com/example/emptyactivity/LoginRegister.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -14,10 +15,20 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+
+data class User ( val username : String, val password : String, val name : String )
 
 @Composable
 fun LoginRegisterScreen(modifier: Modifier = Modifier){
+    var tempUserData = mutableListOf<User> ()
+    tempUserData.add(User("hellokitty", "kitty1234", "katrina"))
+    tempUserData.add(User("dance4life", "hip82hop", "devin"))
+    tempUserData.add(User("maarrrllliie", "pASSW0Rd", "marls <3"))
+    tempUserData.add(User("__ice__tea__", "nine8seven", "trin"))
+    tempUserData.add(User("em.meme.em", "3l3vator", "E M E L I O"))
+
     var optionShown by rememberSaveable { mutableStateOf("") }
 
     Column(Modifier.padding(15.dp), horizontalAlignment = Alignment.CenterHorizontally){
@@ -46,20 +57,60 @@ fun LoginRegisterScreen(modifier: Modifier = Modifier){
             }
         }
         if (optionShown == "Login"){
-            Login(modifier.padding(15.dp))
+            Login(tempUserData, modifier.padding(15.dp))
         }
         else if (optionShown == "Register"){
-            Register(modifier.padding(15.dp))
+            Register(tempUserData, modifier.padding(15.dp))
         }
     }
 }
 
 @Composable
-fun Login(modifier: Modifier = Modifier){
-    Text("Now you can login")
+fun Login(users: MutableList<User>, modifier: Modifier = Modifier){
+    var username by rememberSaveable { mutableStateOf("") }
+    var password by rememberSaveable { mutableStateOf("") }
+    var message by rememberSaveable { mutableStateOf("") }
+
+    Column(modifier.padding(15.dp)){
+        TextField(
+            value = username,
+            onValueChange = { username = it },
+            label = { Text("Enter your username: ")}
+        )
+        TextField(
+            value = password,
+            onValueChange = { password = it },
+            label = { Text("Enter your password: ")}
+        )
+
+        Button(onClick = {
+            message = ""
+            if (username == "" || password == ""){
+                message = "You must enter a username and a password to login."
+            }
+            for (u in users){
+                if (u.username == username){
+                    if (u.password == password){
+                        message = "Welcome $username! You are now logged in."
+                        break
+                    }
+                    else {
+                        message = "Incorrect password."
+                        break
+                    }
+                }
+            }
+            if (message == ""){
+                message = "Invalid username."
+            }
+        }){
+            Text("Let's go!")
+        }
+        Text("$message")
+    }
 }
 
 @Composable
-fun Register(modifier: Modifier = Modifier){
+fun Register(users: List<User>, modifier: Modifier = Modifier){
     Text("Now you can register")
 }

--- a/app/src/main/java/com/example/emptyactivity/LoginRegister.kt
+++ b/app/src/main/java/com/example/emptyactivity/LoginRegister.kt
@@ -15,10 +15,9 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
-data class User ( val username : String, val password : String, val name : String )
+data class User (var username : String, var password : String, var name : String )
 
 @Composable
 fun LoginRegisterScreen(modifier: Modifier = Modifier){
@@ -111,6 +110,58 @@ fun Login(users: MutableList<User>, modifier: Modifier = Modifier){
 }
 
 @Composable
-fun Register(users: List<User>, modifier: Modifier = Modifier){
-    Text("Now you can register")
+fun Register(users: MutableList<User>, modifier: Modifier = Modifier){
+    var username by rememberSaveable { mutableStateOf("") }
+    var password by rememberSaveable { mutableStateOf("") }
+    var passwordVerification by rememberSaveable { mutableStateOf("") }
+    var name by rememberSaveable { mutableStateOf("") }
+    var message by rememberSaveable { mutableStateOf("") }
+
+    Column(modifier.padding(15.dp)){
+        TextField(
+            value = username,
+            onValueChange = { username = it },
+            label = { Text("Enter a new username: ")}
+        )
+        TextField(
+            value = password,
+            onValueChange = { password = it },
+            label = { Text("Enter a new password: ")}
+        )
+        TextField(
+            value = passwordVerification,
+            onValueChange = { passwordVerification = it },
+            label = { Text("Reenter your new password: ")}
+        )
+        TextField(
+            value = name,
+            onValueChange = { name = it },
+            label = { Text("Enter a display name: ")}
+        )
+
+        Button(onClick = {
+            message = ""
+            if (username == "" || password == "" || passwordVerification == "" || name == ""){
+                message = "The username and password fields cannot be empty to be able to create an account."
+            }
+            for (u in users){
+                if (u.username == username){
+                    message = "This username is already taken. Try another one."
+                    break
+                }
+            }
+            if (message == ""){
+                if (password == passwordVerification){
+                    message = "Welcome $name! An account has been created with the username: $username"
+                    //add user to list of existing users here
+                }
+                else {
+                    message = "Both passwords must be the same to create an account."
+                }
+            }
+        }){
+            Text("Let's go!")
+        }
+        Text("$message")
+    }
 }

--- a/app/src/main/java/com/example/emptyactivity/LoginRegister.kt
+++ b/app/src/main/java/com/example/emptyactivity/LoginRegister.kt
@@ -1,0 +1,65 @@
+package com.example.emptyactivity
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun LoginRegisterScreen(modifier: Modifier = Modifier){
+    var optionShown by rememberSaveable { mutableStateOf("") }
+
+    Column(Modifier.padding(15.dp), horizontalAlignment = Alignment.CenterHorizontally){
+        Text("Welcome. Click log in to access the entire app. If you don't already have an account, you can create one by clicking register.")
+        Row(modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceAround){
+            Button(onClick = {
+                if (optionShown != "Login") {
+                    optionShown = "Login"
+                }
+                else {
+                    optionShown = ""
+                }
+            }) {
+                Text("Log in")
+            }
+
+            Button(onClick = {
+                if (optionShown != "Register") {
+                    optionShown = "Register"
+                }
+                else {
+                    optionShown = ""
+                }
+            }) {
+                Text("Register")
+            }
+        }
+        if (optionShown == "Login"){
+            Login(modifier.padding(15.dp))
+        }
+        else if (optionShown == "Register"){
+            Register(modifier.padding(15.dp))
+        }
+    }
+}
+
+@Composable
+fun Login(modifier: Modifier = Modifier){
+    Text("Now you can login")
+}
+
+@Composable
+fun Register(modifier: Modifier = Modifier){
+    Text("Now you can register")
+}

--- a/app/src/main/java/com/example/emptyactivity/MainActivity.kt
+++ b/app/src/main/java/com/example/emptyactivity/MainActivity.kt
@@ -32,6 +32,7 @@ import androidx.navigation.compose.rememberNavController
 import com.example.emptyactivity.navigation.AboutUs
 import com.example.emptyactivity.navigation.GroceryList
 import com.example.emptyactivity.navigation.Home
+import com.example.emptyactivity.navigation.LoginRegister
 import com.example.emptyactivity.navigation.MealPlan
 import com.example.emptyactivity.navigation.Recipes
 
@@ -85,6 +86,11 @@ class MainActivity : ComponentActivity() {
                                 ) {
                                     Icon(Recipes.icon, contentDescription = "Recipes")
                                 }
+                                IconButton(
+                                    onClick = { navController.navigateSingleTopTo(LoginRegister.route) }
+                                ) {
+                                    Icon(LoginRegister.icon, contentDescription = "Login/Register")
+                                }
                             }
                         }
                     }
@@ -112,6 +118,9 @@ class MainActivity : ComponentActivity() {
                         }
                         composable(route = AboutUs.route){
                             AboutUsScreen()
+                        }
+                        composable(route = LoginRegister.route){
+                            LoginRegisterScreen()
                         }
                     }
                 }

--- a/app/src/main/java/com/example/emptyactivity/navigation/MutsuDestination.kt
+++ b/app/src/main/java/com/example/emptyactivity/navigation/MutsuDestination.kt
@@ -1,6 +1,9 @@
 package com.example.emptyactivity.navigation
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.ShoppingCart
 import androidx.compose.material.icons.filled.Star
@@ -28,12 +31,12 @@ object Home : MutsuDestination {
 }
 
 object GroceryList : MutsuDestination {
-    override val icon = Icons.Filled.Star
+    override val icon = Icons.Filled.ShoppingCart
     override val route = "grocery-list"
 }
 
 object MealPlan : MutsuDestination {
-    override val icon = Icons.Filled.ShoppingCart
+    override val icon = Icons.Filled.DateRange
     override val route = "meal-plan"
 }
 
@@ -43,8 +46,13 @@ object Recipes : MutsuDestination {
 }
 
 object AboutUs : MutsuDestination {
-    override val icon = Icons.Filled.Star
+    override val icon = Icons.Filled.FavoriteBorder
     override val route = "about-us"
 }
 
-val mustuTabRowScreens = listOf(Home, Recipes, MealPlan, GroceryList)
+object LoginRegister : MutsuDestination {
+    override val icon = Icons.Filled.AccountCircle
+    override val route = "login-register"
+}
+
+val mustuTabRowScreens = listOf(Home, Recipes, MealPlan, GroceryList, LoginRegister)


### PR DESCRIPTION
### Pull Request Description

What task/requirement is this resolving (link):
This makes progress for issue #18, but doesn't complete all the tasks. It completes issue #12.

Resolution description:
A new screen has been created for login/registration. There is navigation to the screen as well as basic text boxes and input validation for username, password, etc. The login/registration does not change anything about the functionality of the app yet.

Level of Effort (Update from Estimate):
Orignally, the LOE was 4/5, but for this part of the login/register logic, the LOE was closer to a 2.5/5.
---

### Code Checklist
- [x] tested
- [x] linted
- [ ] reviewed
