### PR TITLE
feat: add confirmation popups when editing or deleting a recipe

### DIFF
--- a/app/src/main/java/com/example/emptyactivity/MainActivity.kt
+++ b/app/src/main/java/com/example/emptyactivity/MainActivity.kt
@@ -18,11 +18,9 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
-import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import com.example.emptyactivity.ui.theme.EmptyActivityTheme
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -32,10 +30,11 @@ import androidx.navigation.compose.rememberNavController
 import com.example.emptyactivity.navigation.AboutUs
 import com.example.emptyactivity.navigation.GroceryList
 import com.example.emptyactivity.navigation.Home
+import com.example.emptyactivity.navigation.LoginRegister
 import com.example.emptyactivity.navigation.MealPlan
 import com.example.emptyactivity.navigation.RecipeInformation
 import com.example.emptyactivity.navigation.Recipes
-import com.example.emptyactivity.navigation.LoginRegister
+import com.example.emptyactivity.ui.theme.EmptyActivityTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -131,7 +130,11 @@ class MainActivity : ComponentActivity() {
                             val recipeName =
                                 navBackStackEntry.arguments?.getString(RecipeInformation.recipeNameArg)
 
-                            RecipeInformationScreen(recipeViewModel, recipeName)
+                            RecipeInformationScreen(
+                                recipeViewModel = recipeViewModel,
+                                recipeName = recipeName,
+                                goToRecipeList = { navController.navigateSingleTopTo(Recipes.route) }
+                            )
                         }
                         composable(route = LoginRegister.route){
                             LoginRegisterScreen()
@@ -149,4 +152,3 @@ fun NavHostController.navigateSingleTopTo(route: String) =
 private fun NavHostController.navigateToRecipeInformation(recipeName: String) {
     this.navigateSingleTopTo("${RecipeInformation.route}/$recipeName")
 }
-

--- a/app/src/main/java/com/example/emptyactivity/RecipeInformation.kt
+++ b/app/src/main/java/com/example/emptyactivity/RecipeInformation.kt
@@ -107,12 +107,12 @@ fun RecipeInformationScreen(
      * recipe. Temporary fix until the datastore is implemented in this screen.
      */
     val recipe = recipeViewModel.getRecipeByName(recipeName)
-        ?: Recipe(
-            name = recipeName,
-            ingredients = mutableListOf(),
-            portionYield = 0,
-            webURL = null
-        )
+        ?: createEmptyRecipe(recipeName)
+
+    //TODO: Replace temporary hardcoded values with responsive behavior
+    //Temporary hardcoded values - to be modified when implementing responsive behavior
+    val columnWidth = 320.dp;
+    val spaceBetweenElements = 2.dp;
 
     Box (
         modifier = Modifier.fillMaxSize(),
@@ -120,10 +120,10 @@ fun RecipeInformationScreen(
     ) {
         Column(
             modifier = Modifier
-                .width(320.dp)
+                .width(columnWidth)
                 .fillMaxHeight(),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(2.dp)
+            verticalArrangement = Arrangement.spacedBy(spaceBetweenElements)
         ) {
             //Save and delete buttons
             ButtonRow(
@@ -137,6 +137,15 @@ fun RecipeInformationScreen(
             RecipeForm(recipe = recipe)
         }
     }
+}
+
+private fun createEmptyRecipe(recipeName: String): Recipe{
+    return Recipe(
+        name = recipeName,
+        ingredients = mutableListOf(),
+        portionYield = 0,
+        webURL = null
+    )
 }
 
 @Composable
@@ -161,10 +170,13 @@ fun RecipeForm(
     val invalidStringErrorMessage by remember { mutableStateOf("Please enter a valid string")}
     val invalidIntegerErrorMessage by remember { mutableStateOf("Please enter a valid positive number") }
 
+    //Temporary hardcoded values - to be modified when implementing responsive behavior
+    val spaceBetweenInputFields = 20.dp
+
     Column(
         modifier = modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(20.dp)
+        verticalArrangement = Arrangement.spacedBy(spaceBetweenInputFields)
     ) {
         //Recipe Name
         UserFieldInput(
@@ -176,7 +188,8 @@ fun RecipeForm(
                 if (isNameValid) { recipe.name = nameState }
             },
             isInvalid = !isNameValid,
-            errorMessage = invalidStringErrorMessage
+            errorMessage = invalidStringErrorMessage,
+            modifier = Modifier.fillMaxWidth()
         )
 
         //Ingredients
@@ -199,7 +212,8 @@ fun RecipeForm(
             errorMessage = invalidIntegerErrorMessage,
             keyboardOptions = KeyboardOptions.Default.copy(
                 keyboardType = KeyboardType.Number
-            )
+            ),
+            modifier = Modifier.fillMaxWidth()
         )
 
         //Web URL
@@ -209,7 +223,8 @@ fun RecipeForm(
             onValueChange = {
                 urlState = it
                 recipe.webURL = urlState
-            }
+            },
+            modifier = Modifier.fillMaxWidth()
         )
     }
 }
@@ -281,7 +296,7 @@ private fun isValidPositiveInteger(string: String): Boolean {
  *
  * @param label Label to display on top of the text box
  * @param value Value the field corresponds to
- * @param onValueChange Actions to take when the value of the textbox is changed
+ * @param onValueChange Actions to take when the value of the text box is changed
  * @param isInvalid Whether the user input is valid or not. If true, displays an error message.
  * @param errorMessage Error message to display if the input is invalid.
  * @param keyboardOptions Keyboard options for specific cases. For example, when you want the user to
@@ -297,6 +312,9 @@ fun UserFieldInput(
     errorMessage: String = "Invalid input",
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
 ) {
+    //Temporary hardcoded values - to be modified when implementing responsive behavior
+    val rightPadding = 100.dp
+
     OutlinedTextField(
         value = value,
         onValueChange = onValueChange,
@@ -312,7 +330,7 @@ fun UserFieldInput(
             color = Color.Red,
             fontSize = 12.sp,
             textAlign = TextAlign.Left,
-            modifier = Modifier.padding(end = 100.dp)
+            modifier = Modifier.padding(end = rightPadding)
         )
     }
 }
@@ -342,6 +360,9 @@ fun ButtonRow(
 
     var confirmedDelete by remember { mutableStateOf(false) }
 
+    //Temporary hardcoded values - to be modified when implementing responsive behavior
+    val spaceBetweenButtons = 4.dp
+
     Row(modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.End,
         verticalAlignment = Alignment.CenterVertically
@@ -355,7 +376,7 @@ fun ButtonRow(
             )
         }
 
-        Spacer(modifier = Modifier.width(4.dp))
+        Spacer(modifier = Modifier.width(spaceBetweenButtons))
 
         IconButton(
             onClick = { showDeleteDialog = true }
@@ -416,29 +437,38 @@ fun IngredientDisplay(
     toggleDisplayInputRow: () -> Unit,
     displayInputRow: Boolean
 ) {
+    //Temporary hardcoded values - to be modified when implementing responsive behavior
+    val veryLightGray = Color(244, 244, 244)
+    val roundedCornerRadius = 12.dp
+    val minColumnHeight = 150.dp
+    val maxColumnHeight = 500.dp
+    val columnPadding = 25.dp
+    val spaceBetweenIngredients = 10.dp
+    val spacerHeight = 20.dp
 
-    LazyColumn(
-        verticalArrangement = Arrangement.spacedBy(10.dp),
+    Column(
         modifier = Modifier
-            .background(Color(244, 244, 244))
-            .defaultMinSize(150.dp)
-            .clip(shape = RoundedCornerShape(12.dp))
-            .heightIn(150.dp, 500.dp)
-            .padding(25.dp)
+            .background(veryLightGray)
+            .defaultMinSize(minColumnHeight)
+            .clip(shape = RoundedCornerShape(roundedCornerRadius))
+            .heightIn(minColumnHeight, maxColumnHeight)
+            .padding(columnPadding)
     ) {
-        items(recipe.ingredients) { ingredient ->
-            IngredientDisplayRow(ingredient = ingredient)
+        LazyColumn(
+            verticalArrangement = Arrangement.spacedBy(spaceBetweenIngredients)
+        ) {
+            items(recipe.ingredients) { ingredient ->
+                IngredientDisplayRow(ingredient = ingredient)
+            }
         }
 
-        if (displayInputRow){
-            item {
-                IngredientInputRow(recipe)
-            }
-        }
-        else {
-            item{
-                AddIngredientButton(onClick = toggleDisplayInputRow)
-            }
+        Spacer(Modifier.height(spacerHeight))
+
+        // AddIngredientButton or IngredientInputRow
+        if (displayInputRow) {
+            IngredientInputRow(recipe)
+        } else {
+            AddIngredientButton(onClick = toggleDisplayInputRow)
         }
     }
 }
@@ -449,7 +479,8 @@ fun AddIngredientButton(onClick: () -> Unit) {
         Button(
             modifier = Modifier.fillMaxWidth(),
             onClick = onClick,
-            shape = RectangleShape
+            shape = RectangleShape,
+            enabled = false
         ) {
             Text("Add Ingredient")
         }
@@ -463,16 +494,21 @@ fun AddIngredientButton(onClick: () -> Unit) {
 fun IngredientDisplayRow(
     ingredient: TemporaryIngredient
 ) {
+    //Temporary hardcoded values - to be modified when implementing responsive behavior
+    val spacerWidth = 16.dp
+
     Row(
         modifier = Modifier
             .fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Text(ingredient.quantity.toString())
-        Spacer(modifier = Modifier.width(8.dp))
-        Text(ingredient.measurement.abbreviation)
-        Spacer(modifier = Modifier.width(16.dp))
-        Text(ingredient.name)
+        Text(ingredient.quantity.toString(), modifier = Modifier.weight(0.5f))
+        Text(ingredient.measurement.abbreviation, modifier = Modifier.weight(1f))
+        Spacer(modifier = Modifier
+            .weight(0.5f)
+            .width(spacerWidth)
+        )
+        Text(ingredient.name, modifier = Modifier.weight(3f))
     }
 }
 
@@ -484,6 +520,10 @@ fun IngredientInputRow(recipe: Recipe) {
     var ingredientQuantity by remember { mutableStateOf("") }
     val ingredientMeasurement by remember { mutableStateOf(Measurements.NONE) }
     var ingredientName by remember { mutableStateOf("") }
+
+    //Temporary hardcoded values - to be modified when implementing responsive behavior
+    val quantityFieldWidth = 75.dp
+    val nameFieldWidth = 150.dp
 
     Row(
         modifier = Modifier
@@ -497,9 +537,10 @@ fun IngredientInputRow(recipe: Recipe) {
             label = "Qty",
             value = ingredientQuantity,
             onValueChange = { ingredientQuantity = it },
+            modifier = Modifier.width(quantityFieldWidth),
             keyboardOptions = KeyboardOptions.Default.copy(
                 keyboardType = KeyboardType.Number
-            ),
+            )
         )
 
         //Measurement
@@ -510,7 +551,7 @@ fun IngredientInputRow(recipe: Recipe) {
             label = "Name",
             value = ingredientName,
             onValueChange = { ingredientName = it },
-            modifier = Modifier.width(150.dp)
+            modifier = Modifier.width(nameFieldWidth),
         )
 
         //Submit

--- a/app/src/main/java/com/example/emptyactivity/RecipeListScreen.kt
+++ b/app/src/main/java/com/example/emptyactivity/RecipeListScreen.kt
@@ -31,28 +31,28 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 
+/**
+ * Screen that displays a list of the user's existing recipes. Users can create recipes by entering
+ * a recipe name in the text box and submitting, which will take them to next screen to complete
+ * the newly created recipe's information.
+ *
+ * Users can also click on an existing recipe's card and be redirected to the corresponding recipe's
+ * information screen, where they can edit its information or delete it.
+ *
+ * @param goToRecipeInformation navigation to Recipe Information screen with the recipe name (of the
+ * recipe to be shown) as a navigation argument
+ */
 @Composable
 fun RecipeListScreen(goToRecipeInformation: (String) -> Unit){
-    var recipeName by remember { mutableStateOf("") }
     val recipeViewModel = RecipeViewModel()
 
     Column(
         modifier = Modifier
     ) {
-        RecipeInput(
-            recipeName = recipeName,
-            onRecipeNameChange = { newRecipeName -> recipeName = newRecipeName },
-            onAddButtonClick = {
-                if (recipeName.isNotEmpty()) {
-                    addNewEmptyRecipe(recipeViewModel, recipeName)
-                    goToRecipeInformation(recipeName)
-                    recipeName = ""
-                }
-            },
-            modifier = Modifier
-                .weight(1f)
-        )
+        //Region for users to create a new recipe
+        RecipeInput(recipeViewModel, goToRecipeInformation)
 
+        //Region for users to view a list of their existing recipes
         Section(
             title = "Existing Recipes",
             modifier = Modifier.weight(3f)
@@ -74,14 +74,17 @@ private fun addNewEmptyRecipe(recipeViewModel: RecipeViewModel, recipeName: Stri
     ))
 }
 
-//Contains the textbox that accepts user input and the button that saves it!
+/**
+ * Text box and button for users to create a new recipe. Once submitted, the user is redirected
+ * to a blank recipe form to fill out the rest of the recipe's information.
+ */
 @Composable
 fun RecipeInput(
-    recipeName: String,
-    onRecipeNameChange: (String) -> Unit,
-    onAddButtonClick: () -> Unit,
-    modifier : Modifier
+    recipeViewModel: RecipeViewModel,
+    goToRecipeInformation: (String) -> Unit
 ) {
+    var recipeName by remember { mutableStateOf("") }
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -90,7 +93,7 @@ fun RecipeInput(
     ) {
         OutlinedTextField(
             value = recipeName,
-            onValueChange = { onRecipeNameChange(it) },
+            onValueChange = { recipeName = it },
             label = { Text("Add New Recipe") },
             placeholder = { Text("Recipe Name") },
             modifier = Modifier
@@ -100,7 +103,12 @@ fun RecipeInput(
         )
 
         Button(
-            onClick = { onAddButtonClick() },
+            onClick = {
+                if (recipeName.isNotEmpty()) {
+                    addNewEmptyRecipe(recipeViewModel, recipeName)
+                    goToRecipeInformation(recipeName)
+                    recipeName = ""
+            } },
             modifier = Modifier
                 .weight(1f)
                 .align(Alignment.CenterVertically)

--- a/app/src/main/java/com/example/emptyactivity/RecipeListScreen.kt
+++ b/app/src/main/java/com/example/emptyactivity/RecipeListScreen.kt
@@ -104,7 +104,8 @@ fun RecipeInput(
             modifier = Modifier
                 .weight(1f)
                 .align(Alignment.CenterVertically)
-                .padding(vertical = 8.dp)
+                .padding(vertical = 8.dp),
+            enabled = false
         ) {
             Text("Add")
         }

--- a/app/src/main/java/com/example/emptyactivity/RecipeViewModel.kt
+++ b/app/src/main/java/com/example/emptyactivity/RecipeViewModel.kt
@@ -1,5 +1,6 @@
 package com.example.emptyactivity
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -7,14 +8,17 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
+//ViewModel responsible for managing Recipe data and CRUD operations.
 class RecipeViewModel : ViewModel() {
     private val _recipeList = MutableStateFlow<List<Recipe>>(emptyList())
-    val recipeList: StateFlow<List<Recipe>> = _recipeList.asStateFlow()
+    private val recipeList: StateFlow<List<Recipe>> = _recipeList.asStateFlow()
 
+    //Initializes the ViewModel with sample recipe data.
     init {
         _recipeList.value = instantiateRecipes()
     }
 
+    //Creates and returns a list of sample recipes.
     private fun instantiateRecipes(): List<Recipe> {
         val recipeSeedData = mutableListOf<Recipe>()
 
@@ -138,26 +142,55 @@ class RecipeViewModel : ViewModel() {
         return ingredientList
     }
 
+    /**
+     * Adds a new recipe to the recipe list.
+     *
+     * @param recipe The recipe to be added.
+     */
     fun addRecipe(recipe: Recipe) {
         viewModelScope.launch {
             _recipeList.value = _recipeList.value + recipe
         }
     }
 
+    /**
+     * Removes a recipe from the recipe list.
+     *
+     * @param recipe The recipe to be removed.
+     */
     fun removeRecipe(recipe: Recipe) {
         viewModelScope.launch {
             _recipeList.value = _recipeList.value - recipe
         }
     }
 
+    /**
+     * Retrieves all recipes from the recipe list.
+     *
+     * @return A list of all recipes.
+     */
     fun getAllRecipes(): List<Recipe>{
+        Log.d("DEBUG", "Public: " + recipeList.value.toString())
+        Log.d("DEBUG", "Private: " + _recipeList.value.toString())
         return recipeList.value;
     }
 
+    /**
+     * Retrieves a recipe by its name.
+     *
+     * @param name The name of the recipe to retrieve.
+     * @return The recipe with the specified name, or null if not found.
+     */
     fun getRecipeByName(name: String): Recipe? {
         return _recipeList.value.find { it.name == name }
     }
 
+    /**
+     * Updates an existing recipe in the recipe list.
+     *
+     * @param recipeName The name of the recipe to be updated.
+     * @param updatedRecipe The updated recipe information.
+     */
     fun editRecipe(recipeName: String, updatedRecipe: Recipe) {
         viewModelScope.launch {
             val newList = _recipeList.value.toMutableList()


### PR DESCRIPTION
### Pull Request Description

What task/requirement is this resolving (link):
Adds confirmation popups when editing or deleting a recipe in Recipe Information screen. Navigates back to Recipe List screen when done. Solidifies editing and deleting recipe operations. 

Resolution description:
Added documentation, removed hard coded values and made some slight layout changes as well.

Level of Effort (Update from Estimate):
1/5

---

### Code Checklist
- [ ] tested
- [ ] linted
- [ ] reviewed
