### PR TITLE
fix: update gradle to 8.5

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Oct 04 16:36:50 EDT 2023
+#Sun Dec 17 23:29:49 EST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Pull Request Description

What task/requirement is this resolving (link):
- Closes #93.

Resolution description:
Upgraded the gradle to use 8.5

Level of Effort (Update from Estimate):
LOE would be a 1/5. It took a long time for everything to download and build, but since we did it through Android Studio, everything updated automatically and there was nothing we had to fix.
---

### Code Checklist
- [x] tested
- [x] linted
- [x] reviewed
